### PR TITLE
Attaching the generated .zip to the output of the build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.tibco.plugins</groupId>
     <artifactId>flogo-maven-plugin</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
     <packaging>maven-plugin</packaging>
     <name>Plugin Code for Apache Maven and TIBCO Flogo</name>
     <description>Plugin Code for Apache Maven and TIBCO Flogo.

--- a/src/main/java/com/tibco/flogo/maven/mojo/FlogoPackageMojo.java
+++ b/src/main/java/com/tibco/flogo/maven/mojo/FlogoPackageMojo.java
@@ -8,9 +8,11 @@ import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProjectHelper;
 
 import java.io.File;
 import java.nio.file.Paths;
@@ -49,6 +51,9 @@ public class FlogoPackageMojo extends AbstractMojo {
 
     @Parameter(property = "customFQImage", defaultValue = "")
     private String customFQImage;
+
+    @Component
+    private MavenProjectHelper projectHelper;
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
@@ -102,6 +107,17 @@ public class FlogoPackageMojo extends AbstractMojo {
             FlogoBuildConfig.INSTANCE.setCustomFQImage(customFQImage);
             FlogoPackageRunner runner = new FlogoPackageRunner();
             runner.run();
+
+            File artifactFile = Paths.get(
+                    FlogoBuildConfig.INSTANCE.getOutputPath(),
+                    FlogoBuildConfig.INSTANCE.getArtifactId() + ".zip"
+            ).toFile();
+
+            projectHelper.attachArtifact(
+                    session.getCurrentProject(),
+                    "zip",
+                    artifactFile
+            );
 
         } catch (Exception e) {
             getLog().error(e);


### PR DESCRIPTION
The generated `.zip` file is attached as an artifact to the output of the build. This will allow you to persist the output on any Maven repository by running `mvn deploy` and would mimic the build process of any Java or BW6 project.

This PR should resolve issue #7.